### PR TITLE
Impl rotate

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ SUBCOMMANDS:
 While writing and picking a name for this tool, I discovered both [QPDF](https://github.com/qpdf/qpdf) and [PDFtk ("tool kit") Server](https://www.pdflabs.com/tools/pdftk-server/), both of which offer many more features. This project is definitely not a tool kit, but maybe it's a single tool: a hammer. It's not always the perfect tool for the job, but if you only need something simple to then a hammer might do.
 
 ## Installation Instructions
+
+## Helpful Resources for Understanding PDF Structure
+1. [PDF Explained by John Whitington](https://www.oreilly.com/library/view/pdf-explained/9781449321581/ch04.html)
+2. [PDF 32000-1:2008, The PDF Specification](https://opensource.adobe.com/dc-acrobat-sdk-docs/standards/pdfstandards/pdf/PDF32000_2008.pdf)


### PR DESCRIPTION
Rotate is implemented for the entire document, select pages, or every other nth page (from `--every`).

Rotation degrees must be a multiple of 90, where negative values are CCW rotations, and positive are CW rotations.

Currently, the rotation/orientation degree passed simply replaces the current rotation, rather than adding or subtracting from it. E.g. if a `Page` currently has a `/Rotate` value of `180`, then running:

```
pdfh <input-file> --degrees 90
```

Results in an in-place page rotation to `90` degrees, rather than an additive rotation to `270` degrees.

It is possible this will change if this begins to feel unintuitive. 